### PR TITLE
Correction de bug sur les clés d’interopérabilité

### DIFF
--- a/lib/validator/schema.js
+++ b/lib/validator/schema.js
@@ -15,6 +15,7 @@ exports.fields = {
       const splitted = v.split('_')
       if (splitted.length < 3) {
         errors.push('La clé d’interopérabilité doit contenir au moins 3 segments')
+        return {errors, parsedValue: v}
       }
       const [codeCommune, codeRivoli, numeroVoie, ...suffixes] = splitted
       if (codeCommune.length !== 5) {


### PR DESCRIPTION
Retourne lorsqu'une clé d’interopérabilité contient moins de 3 segments afin d'éviter la vérification de la clé.